### PR TITLE
api.js: searchEvents: do not encode query string

### DIFF
--- a/api.js
+++ b/api.js
@@ -93,7 +93,6 @@ Papertrail.prototype = {
   */
   searchEvents: decorateRequest(function(options) {
     options = options || {};
-    if (options.q) options.q = encodeURI(options.q);
 
     return request.get(this.baseUrl + 'events/search').
             query(options);


### PR DESCRIPTION
encoding query string for `events/search` is not working with the current api. requests that are sent without encoded query strings works fine.
